### PR TITLE
Add executable_options variable

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,6 +41,8 @@
 # @param [String[1]] version
 #   The version of `puppet-runner` to install
 #
+# @param [Optional[String[1]]] executable_options
+#   One or more options to pass to the binary, for example: `-env-reset-delay=100 -debug=true`
 class puppet_runner (
   Stdlib::Absolutepath $exe_folder_path,
   Stdlib::Absolutepath $install_path,
@@ -50,6 +52,7 @@ class puppet_runner (
   String[1] $checksum_filename,
   String[1] $checksum_type,
   String[1] $version,
+  Optional[String[1]] $executable_options = undef,
 ) {
   $_file_owner = $facts['kernel'] ? {
     'windows' => undef,
@@ -118,16 +121,16 @@ class puppet_runner (
   # determine which platform is being targeted and then pass the symlink's path
   # to the corresponding parameter of puppet_run_scheduler
   if $facts['kernel'] == 'windows' {
-    $_posix_exe = undef
-    $_windows_exe = $_exe_symlink
+    $_posix_command = undef
+    $_windows_command = strip("${_exe_symlink} ${executable_options}")
   } else {
-    $_posix_exe = $_exe_symlink
-    $_windows_exe = undef
+    $_posix_command = strip("${_exe_symlink} ${executable_options}")
+    $_windows_command = undef
   }
 
   class { 'puppet_run_scheduler':
     ensure                    => present,
-    posix_puppet_executable   => $_posix_exe,
-    windows_puppet_executable => $_windows_exe,
+    posix_puppet_executable   => $_posix_command,
+    windows_puppet_executable => $_windows_command,
   }
 }

--- a/spec/classes/puppet_runner_spec.rb
+++ b/spec/classes/puppet_runner_spec.rb
@@ -13,6 +13,25 @@ describe 'puppet_runner' do
         allow(win_acl_provider).to receive(:validate).and_return(true)
       end
 
+      context 'with executable_options and version set' do
+        let(:params) do
+          { 'executable_options' => '-foo',
+            'version' => '2.0.0' }
+        end
+
+        if os_facts[:kernel].eql?('windows')
+          it {
+            is_expected.to contain_class('puppet_run_scheduler')
+              .with_windows_puppet_executable('C:/ProgramData/PuppetLabs/puppet-runner/puppet-runner.exe -foo')
+          }
+        else
+          it {
+            is_expected.to contain_class('puppet_run_scheduler')
+              .with_posix_puppet_executable('/opt/puppetlabs/bin/puppet-runner -foo')
+          }
+        end
+      end
+
       context 'with version set to 2.0.0' do
         let(:params) { { 'version' => '2.0.0' } }
 


### PR DESCRIPTION
This change would allow passing options to the puppet_runner binary.  Draft because I don't know if there is a better / preferred way to do this.